### PR TITLE
.gitmodules: Point dynstr to GitHub mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dynstr"]
 	path = dynstr
-	url = https://codeberg.org/xavidcr/dynstr.git
+	url = https://github.com/midokura/dynstr.git


### PR DESCRIPTION
Despite being more reliable than https://gitea.privatedns.org, https://codeberg.org still has reliability issues when abused like we do. Therefore, this commit points to a mirror in GitHub so as to increase reliability.